### PR TITLE
[feat-59] 생성하기 ui 수정 및 아이디 입력칸 아이콘 삭제

### DIFF
--- a/src/assets/scss/Edit/EditMyshop.scss
+++ b/src/assets/scss/Edit/EditMyshop.scss
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: center;
   flex-direction: column;
-  align-items: center;
+  // align-items: center;
   width: 100%;
 
   .shop {

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -43,7 +43,7 @@ const Header = () => {
       </div>
       <div className="header-right">
         {location.pathname === '/create' ? (
-          <Button to="/list">돌아가기</Button>
+          <Button to="/">돌아가기</Button>
         ) : (
           <Button to="/create">생성하기</Button>
         )}

--- a/src/components/common/Create/CreateShopInfo.jsx
+++ b/src/components/common/Create/CreateShopInfo.jsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
+
 import Eyes from '../../../assets/images/eyes.png'
 
 const InfoInput = ({ infoData, setInfoData }) => {
   // 유나 shopInfo 코드 시작
-  const [showId, setShowId] = useState(false)
   const [showPassword, setShowPassword] = useState(false)
 
   const handleChange = e => {
@@ -12,10 +12,6 @@ const InfoInput = ({ infoData, setInfoData }) => {
       ...prev,
       [name]: value,
     }))
-  }
-
-  const toggleId = () => {
-    setShowId(prev => !prev)
   }
 
   const togglePassword = () => {
@@ -50,7 +46,7 @@ const InfoInput = ({ infoData, setInfoData }) => {
         <div className="content-box">
           <span className="content-title">유저 ID</span>
           <input
-            type={showId ? 'text' : 'password'}
+            type="text"
             name="userId"
             value={infoData.userId}
             onChange={handleChange}
@@ -58,7 +54,6 @@ const InfoInput = ({ infoData, setInfoData }) => {
             className="content-comment"
           />
         </div>
-        <img src={Eyes} alt="아이디 보기" className="password-eyes" onClick={toggleId} />
       </div>
       <div className="user-info">
         <div className="content-box">


### PR DESCRIPTION
## #️⃣연관된 이슈

> [feat - 59] 생성하기 UI 깨짐 수정 및 아이디 아이콘 삭제


## 🪄작업 내용

> 생성하기 페이지 내 쇼핑몰 부분 ui깨짐 현상이 발생해 수정하였습니다.
> 생성하기 페이지에서 header 돌아가기 클릭시 홈 화면으로 다시 리디액션 되도록 수정해두었습니다.
> 생성하기 아이디 입력할 때 비밀번호처럼 text 숨김처리 되는 부분 해제하고, 눈 가림 아이콘도 삭제해두었습니다.
-

## 💖리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

-
