### PR TITLE
[Fix -103] 상세페이지 비밀번호확인아이콘수정

### DIFF
--- a/src/assets/scss/EditDeleteModal.scss
+++ b/src/assets/scss/EditDeleteModal.scss
@@ -17,15 +17,15 @@
 /* 최대 해상도 (울트라 4K 이상) */
 @media screen and (min-width: 3000px) {
   .edit-delete-modal {
-    top: 165px;
-    right: 730px;
+    top: 250px;
+    right: 950px;
   }
 }
 
 /* 4K~QHD (2560px) */
 @media screen and (min-width: 2560px) and (max-width: 2999px) {
   .edit-delete-modal {
-    top: 165px;
+    top: 250px;
     right: 730px;
   }
 }
@@ -41,7 +41,7 @@
 /* 1441px ~ 1919px (기존 데스크탑) */
 @media screen and (min-width: 1440px) and (max-width: 1600px) {
   .edit-delete-modal {
-    top: 170px;
+    top: 250px;
     right: 170px;
   }
 }
@@ -55,7 +55,7 @@
 
 @media screen and (min-width: 1025px) and (max-width: 1210px) {
   .edit-delete-modal {
-    top: 160px;
+    top: 250px;
     right: 50px;
   }
 }
@@ -63,7 +63,7 @@
 /* 태블릿 */
 @media screen and (min-width: 768px) and (max-width: 1024px) {
   .edit-delete-modal {
-    top: 160px;
+    top: 250px;
     right: 40px;
     width: 140px;
     font-size: 16px;
@@ -71,10 +71,10 @@
 }
 
 /* 모바일 */
-@media screen and (max-width: 767px) {
+@media screen and (min-width: 320px) and (max-width: 767px) {
   .edit-delete-modal {
-    top: 130px;
-    right: 50px;
+    top: 230px;
+    right: 20px;
     width: 120px;
     font-size: 14px;
   }

--- a/src/assets/scss/ProFileDetail.scss
+++ b/src/assets/scss/ProFileDetail.scss
@@ -86,7 +86,7 @@
   z-index: 11;
 }
 
-.input-password-container {
+.password-input-container {
   position: relative;
   width: 100%;
 }
@@ -101,6 +101,7 @@
   height: 20px;
   background-color: white;
   cursor: pointer;
+  margin: -5px 5px;
 }
 
 .check-delete-button {

--- a/src/pages/Edit.jsx
+++ b/src/pages/Edit.jsx
@@ -2,10 +2,10 @@ import { useState, useEffect } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import axios from 'axios'
 
+import { LinkShopById, updateLinkShop } from '../api/api'
 import EditMyShop from '../components/common/Edit/EditMyshop'
 import EditRepItem from '../components/common/Edit/EditRepItem'
 const LINKSHOP_API_URL = import.meta.env.VITE_LINKSHOP_API_URL
-import { LinkShopById, updateLinkShop } from '../api/api'
 
 const Edit = () => {
   const { linkShopId } = useParams()


### PR DESCRIPTION
## #️⃣연관된 이슈

> #103 

- close: #[issue number]

## 🪄작업 내용

> 수정/삭제 시 비밀번호 입력 인풋 안에 비밀번호 확인하는 eyes 아이콘 위치하게 적용했습니다.
> 반응형도 추가적으로 작업했습니다.

<img width="414" alt="스크린샷 2025-04-28 오후 6 07 27" src="https://github.com/user-attachments/assets/b02eaacd-c72e-470f-abdd-bfabff65a584" />

---

<img width="572" alt="스크린샷 2025-04-28 오후 6 10 19" src="https://github.com/user-attachments/assets/ec3209e6-2a8b-467d-a622-e1300b6fd3b2" />

---

<img width="647" alt="스크린샷 2025-04-28 오후 5 59 40" src="https://github.com/user-attachments/assets/79961a93-2713-424d-9b23-bf2481f0b04a" />

---

## 💖리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

- e913793 : 겹쳤던 코드 제거 (import api 함수)
- 51e2521 : 비밀번호 확인 아이콘 위치 수정
- feb8604 : 반응형 css 수정
