### PR TITLE
[Fix - 119] 상세페이지대표상품 반응형적용

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -16,16 +16,6 @@ export const getShops = async () => {
   }
 }
 
-export const getShopById = async id => {
-  try {
-    const response = await axios.get(`${LINKSHOP_API_URL}/${id}`)
-    return response.data
-  } catch (error) {
-    console.error('에러 출력', error)
-    return null
-  }
-}
-
 export const addLike = async shopId => {
   try {
     const response = await axios.post(`${LINKSHOP_API_URL}/${shopId}/like`)
@@ -126,7 +116,15 @@ export const getShopsByFilter = async (filter, cursor = null) => {
   }
 }
 
-export const LinkShopById = async linkShopId => {
-  const response = await axios.get(`${LINKSHOP_API_URL}/${linkShopId}`)
-  return response.data
+const fetchShopById = async id => {
+  try {
+    const response = await axios.get(`${LINKSHOP_API_URL}/${id}`)
+    return response.data
+  } catch (error) {
+    console.error('에러 출력', error)
+    return null
+  }
 }
+
+export const getShopById = fetchShopById
+export const LinkShopById = fetchShopById

--- a/src/assets/scss/Button.scss
+++ b/src/assets/scss/Button.scss
@@ -1,4 +1,4 @@
-@use '../scss/setting.scss' as *;
+@use './Setting.scss' as *;
 
 .button {
   width: 98px;

--- a/src/assets/scss/DetailPageItemList.scss
+++ b/src/assets/scss/DetailPageItemList.scss
@@ -1,14 +1,21 @@
 @use './Setting.scss' as *;
 
+.page-wrapper {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: hidden;
+  margin: 0 auto;
+}
+
 .shop-card {
   background-color: $text-white-600;
   border-radius: 25px;
-  width: 587px;
-  height: 237px;
-
+  width: 100%;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 20px;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
   position: relative;
 }
 
@@ -16,45 +23,53 @@
   display: flex;
   justify-content: space-between;
 }
+
 .render-item-list {
   display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
   margin-top: 30px;
-  gap: 30px;
-}
-.item-price {
-  font-size: 20px;
-  font-weight: 700;
+
+  flex-direction: row;
+  justify-content: flex-start;
+
+  @media (max-width: 767px) {
+    flex-direction: column;
+    align-items: center;
+  }
 }
 
 .item-name {
   background-color: $text-white-600;
   display: flex;
-  flex-direction: row;
-  gap: 20px;
-  font-size: 17px;
+  align-items: center;
+  gap: 16px;
+  font-size: 16px;
   font-weight: 400;
-  width: 588px;
-  height: 127px;
-  padding: 20px 20px;
-  border-top-left-radius: 24px;
-  border-top-right-radius: 24px;
-  border-bottom-left-radius: 24px;
-  border-bottom-right-radius: 24px;
+  width: calc(50% - 10px);
+  min-width: 280px;
+  padding: 16px;
+  border-radius: 24px;
+
+  @media (max-width: 767px) {
+    width: 100%;
+    min-width: auto;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
 }
 
 .item-image {
   background-color: $text-white-600;
   border-radius: 8px;
-  width: 95px;
-  height: 95px;
-}
+  width: 80px;
+  height: 80px;
 
-.item-title {
-  font-size: 17px;
-  font-weight: 400;
-  width: 78px;
-  height: 20px;
-  margin-bottom: 20px;
+  @media (max-width: 768px) {
+    width: 70px;
+    height: 70px;
+  }
 }
 
 .item-title-price {
@@ -62,4 +77,19 @@
   flex-direction: column;
   justify-content: center;
   width: 100%;
+}
+
+.item-title {
+  font-size: 16px;
+  font-weight: 400;
+  margin-bottom: 12px;
+}
+
+.item-price {
+  font-size: 18px;
+  font-weight: 700;
+
+  @media (max-width: 768px) {
+    font-size: 16px;
+  }
 }

--- a/src/assets/scss/DetailPageItemList.scss
+++ b/src/assets/scss/DetailPageItemList.scss
@@ -1,4 +1,4 @@
-@use '../scss/Setting.scss' as *;
+@use './Setting.scss' as *;
 
 .shop-card {
   background-color: $text-white-600;

--- a/src/assets/scss/ProFileDetail.scss
+++ b/src/assets/scss/ProFileDetail.scss
@@ -1,4 +1,4 @@
-@use '../scss/Setting.scss' as *;
+@use './Setting.scss' as *;
 
 .top-image {
   width: 100%;

--- a/src/pages/Edit.jsx
+++ b/src/pages/Edit.jsx
@@ -5,8 +5,6 @@ import { LinkShopById, updateLinkShop } from '../api/api'
 import EditMyShop from '../components/common/Edit/EditMyshop'
 import EditRepItem from '../components/common/Edit/EditRepItem'
 
-import { LinkShopById, updateLinkShop } from '../api/api'
-
 const Edit = () => {
   const { linkShopId } = useParams()
   const [shopInfo, setShopInfo] = useState(null)


### PR DESCRIPTION
## #️⃣연관된 이슈

- #119 

- close: #[issue number]

## 🪄작업 내용

>  모바일, 태블릿, pc버전에서 반응형으로 적용되도록 수정했습니다.

모바일

<img width="499" alt="스크린샷 2025-04-29 오후 5 52 00" src="https://github.com/user-attachments/assets/a6119f1c-2beb-4215-8522-45cd6140fad0" />

---
태블릿

<img width="490" alt="스크린샷 2025-04-29 오후 5 52 12" src="https://github.com/user-attachments/assets/5cb49a44-15f3-4e37-9d4f-f2c7ce3e9369" />

---
PC

<img width="1306" alt="스크린샷 2025-04-29 오후 5 52 28" src="https://github.com/user-attachments/assets/17d38d8f-06e7-406d-ba21-f3d448075555" />

## 💖리뷰 요청사항

> 특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

- 13a165b
