### PR TITLE
[Fix-121] 메인화면 검색 기능 수정

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -5,9 +5,13 @@ import { FILTER_QUERY_MAP } from '../constants/filterOptions'
 const LINKSHOP_API_URL = import.meta.env.VITE_LINKSHOP_API_URL
 const IMAGE_UPLOAD_URL = import.meta.env.VITE_IMAGE_UPLOAD_URL
 
-export const getShops = async () => {
+// export const getShops = async () => {
+export const getShops = async (keyword = '') => {
   try {
-    const response = await axios.get(`${LINKSHOP_API_URL}`)
+    const url = keyword
+      ? `${LINKSHOP_API_URL}?keyword=${encodeURIComponent(keyword)}`
+      : `${LINKSHOP_API_URL}`
+    const response = await axios.get(url)
 
     return response.data.list
   } catch (error) {
@@ -79,11 +83,20 @@ export const putShopById = async (id, updatedData) => {
   return response.data
 }
 
-export const getShopsByCursor = async (cursor = null) => {
+export const getShopsByCursor = async (cursor = null, keyword = '') => {
   try {
     let url = `${LINKSHOP_API_URL}`
+    const params = []
+
     if (cursor) {
-      url += `?cursor=${cursor}`
+      params.push(`cursor=${cursor}`)
+    }
+    if (keyword) {
+      params.push(`keyword=${encodeURIComponent(keyword)}`)
+    }
+
+    if (params.length > 0) {
+      url += `?${params.join('&')}`
     }
 
     const response = await axios.get(url)

--- a/src/assets/scss/ShopCard/ShopCard.scss
+++ b/src/assets/scss/ShopCard/ShopCard.scss
@@ -3,13 +3,17 @@
 .shop-card {
   background-color: $text-white-600;
   border-radius: 25px;
-  width: 587px;
+  width: 100%;
+  max-width: 587px;
   height: 237px;
 
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   position: relative;
+
+  margin: 0;
+  align-self: flex-start;
 }
 
 .shop-card-header {

--- a/src/assets/scss/ShopList/ShopList.scss
+++ b/src/assets/scss/ShopList/ShopList.scss
@@ -5,12 +5,20 @@
   display: flex;
   flex-wrap: wrap;
   gap: 24px;
-  justify-content: space-between;
+  justify-content: flex-start;
   margin-top: 32px;
+  width: 100%;
+  align-self: flex-start;
+  margin-left: 0;
+  margin-right: auto;
 
   // 각 카드가 전체의 반에서 gap 절반(12px)을 뺀 만큼의 고정 너비를 가지게하는 스타일
   > * {
     flex: 0 0 calc(50% - 12px);
+    max-width: 100%;
+    margin: 0 !important;
+    align-self: flex-start;
+    justify-self: flex-start;
   }
 }
 
@@ -60,8 +68,9 @@
   .shop-list > * {
     flex: 0 0 100%;
     max-width: 100%;
-    display: flex;
-    justify-content: center;
+    margin: 0 !important;
+    align-self: flex-start;
+    justify-self: flex-start;
   }
 }
 
@@ -73,7 +82,8 @@
   .shop-list > * {
     flex: 0 0 100%;
     max-width: 100%;
-    display: flex;
-    justify-content: center;
+    margin: 0 !important;
+    align-self: flex-start;
+    justify-self: flex-start;
   }
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -18,6 +18,12 @@ const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
 
+  const handleLogoClick = () => {
+    sessionStorage.removeItem('searchItem')
+    sessionStorage.removeItem('selectedFilter')
+    window.location.href = '/'
+  }
+
   useEffect(() => {
     const auth = getAuth()
 
@@ -105,7 +111,7 @@ const Header = () => {
   return (
     <header className="header">
       <div className="header-left">
-        <Link to="/">
+        <Link to="/" onClick={handleLogoClick}>
           <img src={logo} alt="Linkshop logo" className="header-logo" />
         </Link>
       </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,23 +1,63 @@
 import { useEffect, useState } from 'react'
 
 import ShopList from '../components/ShopList/ShopList'
-import { getShops } from '../api/api'
+import { getShopsByCursor } from '../api/api'
+import SearchBar from '../components/SearchBar/SearchBar'
 
 const Home = () => {
   const [shopList, setShopList] = useState([])
+  const [searchItem, setSearchItem] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [cursor, setCursor] = useState(null)
+  const [hasMore, setHasMore] = useState(true)
 
   useEffect(() => {
-    const getData = async () => {
-      const data = await getShops()
-      setShopList(data)
+    const fetchInitialShops = async () => {
+      setLoading(true)
+
+      if (searchItem.trim() === '') {
+        const { list, nextCursor } = await getShopsByCursor(null)
+        setShopList(list)
+        setCursor(nextCursor)
+        setHasMore(!!nextCursor)
+        setLoading(false)
+        return
+      }
+
+      const { list, nextCursor } = await getShopsByCursor(null, searchItem)
+      setShopList(list)
+      setCursor(nextCursor)
+      setHasMore(!!nextCursor)
+      setLoading(false)
     }
 
-    getData()
-  }, [])
+    fetchInitialShops()
+  }, [searchItem])
+
+  useEffect(() => {
+    const handleScroll = async () => {
+      const scrollTop = window.scrollY
+      const windowHeight = window.innerHeight
+      const fullHeight = document.body.scrollHeight
+
+      if (scrollTop + windowHeight >= fullHeight - 100 && hasMore && !loading) {
+        setLoading(true)
+        const { list: nextList, nextCursor } = await getShopsByCursor(cursor, searchItem)
+        setShopList(prev => [...prev, ...nextList])
+        setCursor(nextCursor)
+        setHasMore(!!nextCursor)
+        setLoading(false)
+      }
+    }
+
+    window.addEventListener('scroll', handleScroll)
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [cursor, hasMore, loading, searchItem])
 
   return (
     <div>
-      <ShopList list={shopList} />
+      <SearchBar onSearch={setSearchItem} />
+      <ShopList list={shopList} searchItem={searchItem} loading={loading} />
     </div>
   )
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#121 

- close: #121 

## 🪄작업 내용

해당 이슈에 작업 내용 및 원인 작성


## 💖리뷰 요청사항

* fix: Home 컴포넌트에 SearchBar 이동 및 검색 기능 처리
* fix: 검색 시 현재 렌더링 된 데이터가 아닌 전체 데이터를 기준으로 검색할 수 있도록 수정
* 메인화면에서 헤더의 로고 눌렀을 때 리렌더링 되도록 수정 
* fix: shopList의 샵 카드를 왼쪽부터 배치할 수 있도록 구현
* fix: getShops - 키워드를 파라미터를 받아 처리할 수 있도록 수정

-
